### PR TITLE
Fixed curly brackets to parentheses for echo command

### DIFF
--- a/docs/monitoring-as-code/plan-and-apply.md
+++ b/docs/monitoring-as-code/plan-and-apply.md
@@ -27,7 +27,7 @@ Validate that the detectors were created, under the _**ALERTS → Detectors**_. 
 === "Shell Command"
 
     ```text
-    echo ${hostname}
+    echo $(hostname)
     ```
 
  You will see a list of the new detectors and you can search for the prefix that was output from above.


### PR DESCRIPTION
echo command requires parentheses () to return hostname rather than {}