### PR TITLE
Update README.md

### DIFF
--- a/aws/ec2/README.md
+++ b/aws/ec2/README.md
@@ -23,7 +23,7 @@ echo $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 Set the following variables:
 
 - `aws_region`: Which region do you want the instances in?
-- `instance_type`: What kind of instance?
+- `instance_type_aws`: What kind of instance?
 - `aws_instance_count`: How many instances?
 
 Sample command:
@@ -32,7 +32,7 @@ Sample command:
 terraform apply \
 -auto-approve \
 -var="aws_region=eu-central-1" \
--var="instance_type=1" \
+-var="instance_type_aws=t2.xlarge" \
 -var="aws_instance_count=1"
 ```
 


### PR DESCRIPTION
changing "instance_type" to "instance_type_aws" to align with variables.tf. I got this error when trying to run with the original instruction:

" Error: Value for undeclared variable
│
│ A variable named "instance_type" was assigned on the command line, but the root module does not declare a variable of that name. To use this value, add a "variable" block to the configuration."