### PR TITLE
I18n: translate home into Japanese

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -6,8 +6,9 @@ Using [mkdocs-static-i18n](https://github.com/ultrabug/mkdocs-static-i18n) to su
 
 ## ja: Japanese
 
+* Home: Completed in https://github.com/signalfx/observability-workshop/commit/7acff0268af0c8b8b54639ef86f68a187a368b9b
 * Splunk IMT: Completed in https://github.com/signalfx/observability-workshop/commit/c25cee8019fd3e0af3fc908e6f2ca1822984ed51
-* Splunk APM: Cpmpleted in https://github.com/katzchang/observability-workshop/commit/6149d7b079eefed6e26e3699052b3d67c2d315d2
+* Splunk APM: Cpmpleted in https://github.com/signalfx/observability-workshop/commit/6149d7b079eefed6e26e3699052b3d67c2d315d2
 * Splunk On-Call: TBD
 * Splunk Synthetics: TBD
 * Splunk Resources: TBD

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -1,0 +1,4 @@
+---
+template: home.ja.html
+title: Splunk Observability Cloud ワークショップ
+---

--- a/overrides/home.ja.html
+++ b/overrides/home.ja.html
@@ -1,0 +1,66 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% extends "main.html" %}
+
+{% block tabs %}
+  {{ super() }}
+  <style>
+    .md-header {position: initial}
+
+    .md-main__inner {margin: 0}
+    
+    .md-content {display: none}
+    
+    body {
+      background: url("images/background.svg") no-repeat;
+      background-size: cover;
+      background-color: var(--md-default-bg-color);
+      background-position: 0 80px;
+      height: 100%;
+    }
+    .mdx-hero {
+      margin: 0 .8rem;
+    }
+    .mdx-hero h1 {
+      margin-bottom: 1rem;
+      font-weight: 700
+    }
+    @media screen and (min-width:60em) {
+      .md-sidebar--secondary {
+        display: none
+      }
+      .mdx-hero {
+        display: flex;
+        align-items: stretch;
+        justify-items: space-between
+      }
+      .mdx-hero__content {
+        max-width: 20rem;
+        margin-top: 3.5rem;
+        padding-bottom: 14vw
+      }
+    }
+    @media screen and (min-width:76.25em) {
+      .md-sidebar--primary {
+        display: none
+      }
+    }
+  </style>
+<section class="mdx-container">
+  <div class="md-grid md-typeset">
+    <div class="mdx-hero">
+      <div class="mdx-hero__content">
+        <h1>End-to-Endのオブザーバビリティ（可観測性）</h1>
+        <h2>Splunk Observability Cloud の監視、分析、オンコールツールを使って、アプリケーションやインフラをリアルタイムに把握しましょう！</h2>
+        <p style="font-size: 0.9em">このワークショップでは、メトリクス、トレース、スパンをインジェスト、モニタリング、ビジュアル化、分析するためのクラス最高のオブザーバビリティ・プラットフォームをご紹介します。</p>
+        <a href="{{ page.next_page.url | url }}" title="{{ page.next_page.title | striptags }}" class="md-button md-button--primary">
+          始める
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+{% block content %}{% endblock %}
+{% block footer %}{% endblock %}


### PR DESCRIPTION
Translated the text of Home into Japanese.

- In home.html, it says `Do not edit this`, but it seemed easiest to add home.en.html, so please give me your opinion if this modification is acceptable
-  Should I advance the current version by one like https://github.com/signalfx/observability-workshop/commit/7acff0268af0c8b8b54639ef86f68a187a368b9b ?
