### PR TITLE
modularizing outputs and adding some default values

### DIFF
--- a/aws/ec2/README.md
+++ b/aws/ec2/README.md
@@ -26,7 +26,7 @@ Set the following variables:
 - `aws_instance_type`: What kind of instance?
 - `aws_instance_count`: How many instances?
 
-Sample command:
+You can also explicitly set variables as command line flags. Sample command:
 
 ```
 terraform apply \

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -86,6 +86,3 @@ resource "aws_instance" "observability-instance" {
 
 }
 
-output "ip" {
-  value = aws_instance.observability-instance.*.public_ip
-}

--- a/aws/ec2/outputs.tf
+++ b/aws/ec2/outputs.tf
@@ -1,0 +1,3 @@
+output "ip" {
+  value = aws_instance.observability-instance.*.public_ip
+}

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -1,9 +1,11 @@
 variable "aws_instance_count" {
   description = "Instance Count (Usually 1)"
+  default = 1
 }
 
 variable "aws_region" {
   description = "Provide the desired region (for example: us-west-2)"
+  # suggest putting a default region here
 }
 
 data "aws_ami" "latest-ubuntu" {


### PR DESCRIPTION
Suggest we include a default region (ex: us-west-1) as sometimes Terraform might not recognize a default VPC in some regions. Alternatively, can create a VPC as part of `main.tf`.