### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ If you are the host for the RUM workshop, please check this [README](https://git
 Latest versions of the workshop are:
 - [v3.11](https://signalfx.github.io/observability-workshop/v3.11/)
 - [v3.10](https://signalfx.github.io/observability-workshop/v3.10/)
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.