### PR TITLE
Update documentation of AWS script to start workshop.

### DIFF
--- a/aws/ec2/README.md
+++ b/aws/ec2/README.md
@@ -43,7 +43,7 @@ Install the prerequisites, e.g. on Mac: `brew install terraform jq pssh`
 
 Then use the script:
 ```
-./up 12 myproject eu-central-1
+./up myproject 12 eu-central-1
 ```
 
 This will create a terraform workspace `o11y-for-myproject`, request 12 instances and ensure all instances have completed provisioning.


### PR DESCRIPTION
Parameters of script in documentation were not in the same order as expected by the script.
Moved the number of instance to the second position in the documentation, as expected by the script.